### PR TITLE
WBK-21: Update uglifier requirements to `~> 2.7.2`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hanuman (2.6.5)
+    hanuman (3.0)
       active_model_serializers (~> 0.8.1)
       acts-as-taggable-on (~> 4.0.0)
       amoeba (~> 3.1.0)
@@ -96,10 +96,9 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
-    connection_pool (2.4.1)
+    connection_pool (2.2.5)
     crass (1.0.6)
     database_cleaner (1.8.5)
-    date (3.3.4)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -111,7 +110,7 @@ GEM
       railties (>= 3.2)
     ember-cli-rails-assets (0.6.2)
     erubis (2.7.0)
-    execjs (2.9.1)
+    execjs (2.9.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)
@@ -158,29 +157,17 @@ GEM
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.1)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     method_source (0.9.2)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0806)
-    mini_mime (1.1.5)
+    mini_mime (1.1.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     modernizr-rails (2.7.1)
     multi_json (1.15.0)
-    net-imap (0.3.7)
-      date
-      net-protocol
-    net-pop (0.1.2)
-      net-protocol
-    net-protocol (0.2.2)
-      timeout
-    net-smtp (0.5.0)
-      net-protocol
     netrc (0.11.0)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -199,7 +186,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (1.6.13)
-    rack-protection (3.0.6)
+    rack-protection (2.2.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -301,7 +288,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (1.4.1)
-    timeout (0.4.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (2.7.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hanuman (2.5)
+    hanuman (2.6.5)
       active_model_serializers (~> 0.8.1)
       acts-as-taggable-on (~> 4.0.0)
       amoeba (~> 3.1.0)
@@ -23,7 +23,7 @@ PATH
       roo (~> 2.3.2)
       sass-rails (~> 4.0.3)
       sidekiq (~> 5)
-      uglifier (~> 2.5.3)
+      uglifier (~> 2.7.2)
 
 GEM
   remote: https://rubygems.org/
@@ -74,7 +74,7 @@ GEM
     ast (2.4.1)
     aws_cf_signer (0.1.3)
     builder (3.2.4)
-    carrierwave (1.3.3)
+    carrierwave (1.3.4)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -96,9 +96,10 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crass (1.0.6)
     database_cleaner (1.8.5)
+    date (3.3.4)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -110,7 +111,7 @@ GEM
       railties (>= 3.2)
     ember-cli-rails-assets (0.6.2)
     erubis (2.7.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     factory_bot_rails (4.11.1)
@@ -134,14 +135,14 @@ GEM
     hike (1.2.3)
     html_page (0.1.0)
     http-accept (1.7.0)
-    http-cookie (1.0.5)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jquery-rails (3.1.5)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (2.6.3)
+    json (2.7.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -157,17 +158,29 @@ GEM
     loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     method_source (0.9.2)
-    mime-types (3.4.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0218.1)
-    mini_mime (1.1.2)
+    mime-types-data (3.2024.0806)
+    mini_mime (1.1.5)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     modernizr-rails (2.7.1)
     multi_json (1.15.0)
+    net-imap (0.3.7)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.0)
+      net-protocol
     netrc (0.11.0)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -186,7 +199,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (1.6.13)
-    rack-protection (2.2.4)
+    rack-protection (3.0.6)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -218,7 +231,7 @@ GEM
       rake
     rake (13.0.1)
     redis (4.8.1)
-    request_store (1.5.1)
+    request_store (1.7.0)
       rack (>= 1.4)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
@@ -288,14 +301,15 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (1.4.1)
+    timeout (0.4.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    uglifier (2.5.3)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     unicode-display_width (1.7.0)
 
 PLATFORMS

--- a/hanuman.gemspec
+++ b/hanuman.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml-rails', '~> 0.5.3'
   s.add_dependency 'coffee-rails', '~> 4.0.1'
   s.add_dependency 'sass-rails', '~> 4.0.3'
-  s.add_dependency 'uglifier', '~> 2.5.3'
+  s.add_dependency 'uglifier', '~> 2.7.2'
   s.add_dependency 'modernizr-rails', '~> 2.7.1'
   s.add_dependency 'jquery-rails', '~> 3.1.1'
   s.add_dependency 'ember-cli-rails', '~> 0.10.0'

--- a/lib/hanuman/version.rb
+++ b/lib/hanuman/version.rb
@@ -1,3 +1,3 @@
 module Hanuman
-  VERSION = "2.6.5"
+  VERSION = "3.0"
 end


### PR DESCRIPTION
The current version of uglifier is vulnerable. See the report below:

```
Name: uglifier
Version: 2.5.3
CVE: CVE-2015-8857
GHSA: GHSA-34r7-q49f-h37c
Criticality: Critical
URL: https://github.com/mishoo/UglifyJS2/issues/751
Title: uglifier incorrectly handles non-boolean comparisons during minification
Solution: upgrade to '>= 2.7.2'
```

This PR merely updates the version requirement for hanuman to fix this issue.