### PR TITLE
WBK-29: Update Hanuman for Rails 5 support

### DIFF
--- a/app/helpers/hanuman/application_helper.rb
+++ b/app/helpers/hanuman/application_helper.rb
@@ -39,7 +39,7 @@ module Hanuman
       if path_call_string
         link_to raw(title), eval(path_call_string+"(params.merge(:sort => column.gsub('*,', '!').gsub(',', ' ' + direction + ',').gsub('*', ' asc').gsub('!', ' asc,'), :direction => direction, :page => nil))"), {:class => css_class}
       else
-        link_to raw(title), params.merge(:sort => column.gsub('*,', '!').gsub(',', ' ' + direction + ',').gsub('*', ' asc').gsub('!', ' asc,'), :direction => direction, :page => nil), {:class => css_class}
+        link_to raw(title), request.params.merge(:sort => column.gsub('*,', '!').gsub(',', ' ' + direction + ',').gsub('*', ' asc').gsub('!', ' asc,'), :direction => direction, :page => nil), {:class => css_class}
       end
     end
 

--- a/hanuman.gemspec
+++ b/hanuman.gemspec
@@ -17,17 +17,17 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '~> 4.2.11.3'
+  s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'responders', '~> 2.0'
   s.add_dependency 'paper_trail', '~> 6.0'
   s.add_dependency 'ancestry' #, '~> 3.0.2'
   s.add_dependency 'amoeba', '~> 3.1.0'
   s.add_dependency 'haml-rails', '~> 0.5.3'
-  s.add_dependency 'coffee-rails', '~> 4.0.1'
+  s.add_dependency 'coffee-rails', '~> 4.1.1'
   s.add_dependency 'sass-rails', '~> 4.0.3'
   s.add_dependency 'uglifier', '~> 2.7.2'
   s.add_dependency 'modernizr-rails', '~> 2.7.1'
-  s.add_dependency 'jquery-rails', '~> 3.1.1'
+  s.add_dependency 'jquery-rails', '~> 4.0.1'
   s.add_dependency 'ember-cli-rails', '~> 0.10.0'
   s.add_dependency 'cocaine', '~> 0.5.8'
   s.add_dependency 'kaminari', '~> 1.2.2'

--- a/hanuman.gemspec
+++ b/hanuman.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'amoeba', '~> 3.1.0'
   s.add_dependency 'haml-rails', '~> 0.5.3'
   s.add_dependency 'coffee-rails', '~> 4.1.1'
-  s.add_dependency 'sass-rails', '~> 4.0.3'
+  s.add_dependency 'sass-rails', '5.0.7' # requires railties < 6, >= 4.0.0
   s.add_dependency 'uglifier', '~> 2.7.2'
   s.add_dependency 'modernizr-rails', '~> 2.7.1'
-  s.add_dependency 'jquery-rails', '~> 4.0.1'
+  s.add_dependency 'jquery-rails', '~> 4.2.0'
   s.add_dependency 'ember-cli-rails', '~> 0.10.0'
   s.add_dependency 'cocaine', '~> 0.5.8'
   s.add_dependency 'kaminari', '~> 1.2.2'
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   # upgrading to 1.0 or 1.1 broke the API on survey create - photo hash was empty-kdh
   s.add_dependency 'carrierwave', '~> 1.3.3'
   s.add_dependency 'cloudinary', '~> 1.25.0'
-  s.add_dependency 'sidekiq', '~> 5'
+  s.add_dependency 'sidekiq', '~> 5.2.10'
   s.add_dependency 'gmaps4rails', '~> 2.1.2'
   s.add_dependency 'pg_search', '~> 2.0.1'
 

--- a/lib/hanuman/version.rb
+++ b/lib/hanuman/version.rb
@@ -1,3 +1,3 @@
 module Hanuman
-  VERSION = "3.0"
+  VERSION = "3.1"
 end


### PR DESCRIPTION
Jira ID: https://ombulabs.atlassian.net/browse/WBK-29

This PR updates the following dependencies in Hanuman to support Rails 5:
* Rails 
* Sass-rails
* jquery-rails
* Sidekiq

We also updated the `sortable` helper due to this error we were getting during smoke testing:

```
ActionView::Template::Error (Attempting to generate a URL from non-sanitized request parameters! An attacker can inject malicious data into the generated URL, such as changing the host. Whitelist and sanitize passed parameters to be secure.)
```

We also changed the version number to reflect the updates.